### PR TITLE
Add Datadog Agent ARMv7 builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.13.5
+
+ENV VERSION 7.16.0
+ENV GOOS linux
+ENV GOARCH arm
+ENV GOARM 7
+ENV AGENT_FOLDER /go/src/github.com/DataDog/datadog-agent
+
+# Agent checkout to $VERSION
+RUN git clone https://github.com/DataDog/datadog-agent.git $AGENT_FOLDER -b $VERSION
+
+# Install build dependencies (NOTE: still Python 2)
+RUN apt-get update && apt-get install -y \
+    python-pip \
+    cmake && \
+  rm -rf /var/lib/apt/lists/* && \
+  curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh && \
+  cd $AGENT_FOLDER && pip install -r requirements.txt
+
+# Pull Agent dependencies
+RUN cd $AGENT_FOLDER && \
+  invoke deps && \
+  mkdir target
+
+# Running the container means building the `puppy` Agent
+CMD cd $AGENT_FOLDER && \
+  GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM invoke agent.build --puppy && \
+  mv bin/agent/dist bin/agent/datadog-agent && \
+  tar cvf ./target/agent-armv7-$VERSION.tar.gz -C bin/agent/ .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# datadog-armv7-builder
-Unofficial Datadog ARMv7 builder
+# Datadog ARMv7 Builder
+
+The present repository provides a Docker image to build the [Datadog Agent][1]
+from source. The build happens in two steps:
+1. Building the container using the `Dockerfile`, creates a container with needed
+  requirements.
+2. Running the container, triggers the actual build.
+
+**Note:** This is an unofficial repository to build the Datadog Agent for ARMv7
+CPUs. For supported platforms and CPUs, check the [Datadog Agent documentation][2].
+
+## Quickstart
+
+Clone the repository and run the following `docker` (or `podman`) commands:
+
+```bash
+$ git clone git@github.com:palazzem/datadog-armv7-builder.git && cd datadog-armv7-builder
+$ docker build -t dd-agent-armv7-builder:latest .
+$ docker run -ti --rm -v $(pwd)/out:/go/src/github.com/DataDog/datadog-agent/target dd-agent-armv7-builder:latest
+```
+
+After the process finishes, you can find the Agent build inside the `out/` folder.
+
+## Pre-built Agents
+
+You can find some releases I've prepare for my usage in the [Release page][3].
+
+[1]: https://github.com/datadog/datadog-agent
+[2]: https://docs.datadoghq.com/agent/
+[3]: https://github.com/palazzem/datadog-armv7-builder/releases

--- a/out/.gitignore
+++ b/out/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
### Overview

This PR adds an **unofficial build** method to build the Datadog Agent for ARMv7 processors. A `Dockerfile` is available to prepare the build environment with needed dependencies. The `puppy` version of the Agent is built, so most of the functionalities are not available.

For official builds, check the [Datadog Agent documentation](https://docs.datadoghq.com/agent/).