### PR TITLE
Use GitHub Actions to build and upload the ARMv7 package as an artifact

### DIFF
--- a/.github/workflows/agent-builder.yml
+++ b/.github/workflows/agent-builder.yml
@@ -1,0 +1,18 @@
+name: Agent ARMv7 Builder
+on:
+  push:
+    branches:
+      - master  # Build the package only on `master`
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Prepare the build environment
+      run: docker build -t dd-agent-armv7-builder:latest .
+    - name: Build the package for ARMv7
+      run: docker run --rm -v $(pwd)/out:/go/src/github.com/DataDog/datadog-agent/target dd-agent-armv7-builder:latest
+    - uses: actions/upload-artifact@v1
+      with:
+        name: agent-armv7-package
+        path: out/

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ Clone the repository and run the following `docker` (or `podman`) commands:
 ```bash
 $ git clone git@github.com:palazzem/datadog-armv7-builder.git && cd datadog-armv7-builder
 $ docker build -t dd-agent-armv7-builder:latest .
-$ docker run -ti --rm -v $(pwd)/out:/go/src/github.com/DataDog/datadog-agent/target dd-agent-armv7-builder:latest
+$ docker run --rm -v $(pwd)/out:/go/src/github.com/DataDog/datadog-agent/target dd-agent-armv7-builder:latest
 ```
 
 After the process finishes, you can find the Agent build inside the `out/` folder.
 
-## Pre-built Agents
+## Automatic Builds
 
-You can find some releases I've prepare for my usage in the [Release page][3].
+Every time a commit lands on `master`, a [GitHub action is executed][3] to build the
+container, and later the package. The output of the build is available as an artifact.
 
 [1]: https://github.com/datadog/datadog-agent
 [2]: https://docs.datadoghq.com/agent/
-[3]: https://github.com/palazzem/datadog-armv7-builder/releases
+[3]: https://github.com/palazzem/datadog-armv7-builder/actions


### PR DESCRIPTION
### Overview

Closes #2 

This PR enables GitHub Actions to build the container and later the package. Every time a commit lands on `master`, the GitHub action is executed and the output of the build is available as an artifact.

[Example](https://github.com/palazzem/datadog-armv7-builder/commit/12d99fc7073b8628064be127e0f077b29cf42167/checks?check_suite_id=385065982)