### PR TITLE
Update Agent builder

### DIFF
--- a/.github/workflows/agent-builder.yml
+++ b/.github/workflows/agent-builder.yml
@@ -1,17 +1,23 @@
 name: Agent ARMv7 Builder
+
 on:
   push:
     branches:
       - master  # Build the package only on `master`
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
     - name: Prepare the build environment
       run: docker build -t dd-agent-armv7-builder:latest .
+
     - name: Build the package for ARMv7
       run: docker run --rm -v $(pwd)/out:/go/src/github.com/DataDog/datadog-agent/target dd-agent-armv7-builder:latest
+
     - uses: actions/upload-artifact@v1
       with:
         name: agent-armv7-package

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Datadog ARMv7 Builder
 
+[![Agent ARMv7 Builder](https://github.com/palazzem/datadog-armv7-builder/workflows/Agent%20ARMv7%20Builder/badge.svg)](https://github.com/palazzem/datadog-armv7-builder/actions?query=workflow%3A%22Agent+ARMv7+Builder%22)
+
 The present repository provides a Docker image to build the [Datadog Agent][1]
 from source. The build happens in two steps:
 1. Building the container using the `Dockerfile`, creates a container with needed


### PR DESCRIPTION
### Overview

The latest Agent [build fails](https://github.com/palazzem/datadog-armv7-builder/runs/541897834?check_suite_focus=true#step:4:18) with:
```
 -- Could NOT find Python3 (missing: Python3_EXECUTABLE Python3_LIBRARY Python3_INCLUDE_DIR Interpreter Development) 
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
/go/src/github.com/DataDog/datadog-agent/rtloader/three/Python3_INCLUDE_DIR
   used as include directory in directory /go/src/github.com/DataDog/datadog-agent/rtloader/three
Python3_LIBRARY
    linked by target "datadog-agent-three" in directory /go/src/github.com/DataDog/datadog-agent/rtloader/three

-- Configuring incomplete, errors occurred!
See also "/go/src/github.com/DataDog/datadog-agent/rtloader/build/CMakeFiles/CMakeOutput.log".
```

This PR addresses the issue.